### PR TITLE
Add more robust json encoding support

### DIFF
--- a/parser/api.go
+++ b/parser/api.go
@@ -96,6 +96,30 @@ type Log struct {
 	Metadata    map[string]interface{}
 }
 
+func (l *Log) Merge(other *Log) {
+	if other.Timestamp != 0 && other.Timestamp != l.Timestamp {
+		l.Timestamp = other.Timestamp
+	}
+	if other.Severity != 0 && other.Severity != l.Severity {
+		l.Severity = other.Severity
+	}
+	if other.RemoteAddr != "" {
+		l.RemoteAddr = other.RemoteAddr
+	}
+	if other.Hostname != "" {
+		l.Hostname = other.Hostname
+	}
+	if other.Application != "" {
+		l.Application = other.Application
+	}
+	if other.Text != "" {
+		l.Text = other.Text
+	}
+	for k, v := range other.Metadata {
+		l.Metadata[k] = v
+	}
+}
+
 // PrettyPrint ...
 func (l *Log) PrettyPrint() {
 	var metadata []string

--- a/parser/app_parsers.go
+++ b/parser/app_parsers.go
@@ -11,7 +11,7 @@ func parseApp(msg *Log) {
 
 // systemd and auth don't come in with the header so we need to add it to parse them
 func parseSystemd(msg *Log) {
-	if m, _ := parseLine([]byte("<6> " + msg.Text)); m != nil {
+	if m, _ := parseSyslogLine([]byte("<6> " + msg.Text)); m != nil {
 		msg.Application = m.Application
 		msg.Text = m.Text
 

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -101,7 +101,6 @@ func detectMaybeJSON(line []byte) (ok bool, result []byte) {
 			continue
 		case '}':
 			farIndex = i
-			break
 		default:
 			return
 		}

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -747,9 +747,6 @@ func Benchmark_detectMaybeJSON(b *testing.B) {
 }
 
 func Test_detectMaybeJSON(t *testing.T) {
-	type args struct {
-		line []byte
-	}
 	tests := []struct {
 		name       string
 		line       []byte


### PR DESCRIPTION
this commit enables the usecase of json messages being encoded into the
MSG field of a syslog message, for example:
```
<12> {"foo": "bar"}
<14>Jan  1 14:40:51 host app[24]: {"foo": "bar"}
```

closes axiomhq/axiom#2250

----
this ended up being a little bit more awkward than I would like, but functionally it became a case of 

 1. look for an early indicator of json being a part of the line, `}` near the end is a good indicator
 2. look for a matching start brace, this doesn't mean we have valid json it just means this is probably json
 3. ignore syslog PRE values when looking for a start match for `<12> {}` situations 
 4. if we found a start and end brace, try and parse as json and fallback to syslog on error
 5. no start and end brace then just parse syslog
 6. run the same detection on the MSG value of the parsed syslog, merge the json attributes with the syslog attributes

the extra detection steps are going to slow parsing but benchmarking suggests that this only becomes measurable in special cases like extreme levels of whitespace padding