### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Production image based on distroless.
-FROM gcr.io/distroless/static-debian11:nonroot
+FROM gcr.io/distroless/static-debian11
 LABEL maintainer="Axiom, Inc. <info@axiom.co>"
 
 # Copy binary into image.
-COPY --chown=nonroot:nonroot axiom-syslog-proxy /usr/bin/axiom-syslog-proxy
+COPY axiom-syslog-proxy /usr/bin/axiom-syslog-proxy
 
 # Use the project name as working directory.
 WORKDIR /axiom-syslog-proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY axiom-syslog-proxy /usr/bin/axiom-syslog-proxy
 # Use the project name as working directory.
 WORKDIR /axiom-syslog-proxy
 
-# Expose the default application port.
-EXPOSE 3101/tcp
+# Expose the default application ports.
+EXPOSE 514/udp 601/tcp
 
 # Set the binary as entrypoint.
 ENTRYPOINT [ "/usr/bin/axiom-syslog-proxy" ]


### PR DESCRIPTION
@lukasmalkmus I'm so sorry! I just noticed that we can't run it as nonroot!

```
2023-08-10T13:54:16.212 app[91857559c17998] nrt [info] {"level":"info","ts":1691675656.2120683,"logger":"axiom-syslog-proxy","caller":"cmd/cmd.go:71","msg":"starting","release":"0.6.0","revision":"edef102","build_date":"2023-08-09T11:41:52Z","build_user":"goreleaser","go_version":"go1.20.7"}

2023-08-10T13:54:16.212 app[91857559c17998] nrt [info] {"level":"info","ts":1691675656.2124286,"logger":"axiom-syslog-proxy","caller":"cmd/cmd.go:106","msg":"started"}

2023-08-10T13:54:16.212 app[91857559c17998] nrt [info] {"level":"error","ts":1691675656.2128325,"logger":"axiom-syslog-proxy","caller":"cmd/cmd.go:113","msg":"create server","error":"listen tcp :601: bind: permission denied"}

2023-08-10T13:54:16.213 app[91857559c17998] nrt [info] {"level":"warn","ts":1691675656.2129228,"logger":"axiom-syslog-proxy","caller":"cmd/cmd.go:60","msg":"stopped"}
```

This affects all users using latest, so I think it needs a quick release!