### PR TITLE
Fix json escaped character handling

### DIFF
--- a/cmd/axiom-syslog-proxy/main.go
+++ b/cmd/axiom-syslog-proxy/main.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"flag"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/axiomhq/axiom-go/axiom"
 	"github.com/axiomhq/pkg/cmd"
@@ -40,15 +38,7 @@ func run(ctx context.Context, _ *zap.Logger, client *axiom.Client) error {
 		return cmd.Error("create server", err)
 	}
 
-	// Setup cancellation context that will be cancelled on receiving a signal
-	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
+	srv.Run(ctx)
 
-	go func() {
-		srv.Run()
-	}()
-
-	<-ctx.Done()
-
-	return ctx.Err()
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/axiomhq/axiom-syslog-proxy
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/axiomhq/axiom-go v0.17.5

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -105,6 +105,24 @@ func (s *ParseTestSuite) TestParseJson() {
 			severity:    int64(Trace),
 			metadata:    map[string]interface{}{"forwind.favourites.artist": "Rune Clausen", "bool": "true", "forwind.favourites.release.link.type.origin": "home", "forwind.favourites.album": "Blindlight", "forwind.favourites.release.duration": int64(100), "forwind.favourites.release.catno": "fwd09", "forwind.favourites.release.link.url": "http://www.forwind.net"},
 		},
+		{
+			raw:         []byte(fmt.Sprintf("<34>1 %s mymachine.example.com su - ID47 - {\"level\":\"error\",\"service\":\"public-service\",\"env\":\"production\",\"error\":\"fail\",\"time\":\"2024-04-05T05:47:24Z\",\"req_id\":\"req-id\",\"message_inside\":\"this will work due to \\\" quote foobar\"}", nowFormatted)),
+			time:        now,
+			application: "su",
+			hostname:    "mymachine.example.com",
+			text:        "{\"level\":\"error\",\"service\":\"public-service\",\"env\":\"production\",\"error\":\"fail\",\"time\":\"2024-04-05T05:47:24Z\",\"req_id\":\"req-id\",\"message_inside\":\"this will work due to \\\" quote foobar\"}",
+			severity:    int64(Error),
+			metadata:    map[string]interface{}{"error": "fail", "time": "2024-04-05T05:47:24Z", "req_id": "req-id", "message_inside": "this will work due to \" quote foobar", "service": "public-service", "env": "production"},
+		},
+		{
+			raw:         []byte(fmt.Sprintf("<34>1 %s mymachine.example.com su - ID47 - {\"level\":\"error\",\"service\":\"public-service\",\"env\":\"production\",\"error\":\"fail\",\"time\":\"2024-04-05T05:47:24Z\",\"req_id\":\"req-id\",\"message\":\"this will work due to \\\" quote foobar\"}", nowFormatted)),
+			time:        now,
+			application: "su",
+			hostname:    "mymachine.example.com",
+			text:        "this will work due to \" quote foobar",
+			severity:    int64(Error),
+			metadata:    map[string]interface{}{"service": "public-service", "env": "production", "error": "fail", "time": "2024-04-05T05:47:24Z", "req_id": "req-id"},
+		},
 	}
 
 	for number, c := range cases {

--- a/parser/syslog.go
+++ b/parser/syslog.go
@@ -303,7 +303,7 @@ func parseRFC5424(msg *Log, data []byte, length int) error {
 	if !valid {
 		return errCorruptedData
 	}
-	msg.Text = cleanString(textData, false)
+	msg.Text = textData
 
 	parseMetadata(msg, data[i:])
 

--- a/server/server.go
+++ b/server/server.go
@@ -122,6 +122,8 @@ func (srv *Server) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			srv.tcpCloser.Close()
+			srv.udpCloser.Close()
 			srv.Flush()
 			return
 		case <-ticker.C:

--- a/server/server.go
+++ b/server/server.go
@@ -110,7 +110,7 @@ func (srv *Server) Flush() error {
 	return nil
 }
 
-func (srv *Server) Run() {
+func (srv *Server) Run(ctx context.Context) {
 	if srv.started {
 		log.Print("server already running")
 		return
@@ -118,11 +118,11 @@ func (srv *Server) Run() {
 
 	srv.started = true
 	ticker := time.NewTicker(5 * time.Second)
-	done := make(chan bool)
 
 	for {
 		select {
-		case <-done:
+		case <-ctx.Done():
+			srv.Flush()
 			return
 		case <-ticker.C:
 			srv.Flush()


### PR DESCRIPTION
When cleanString was called on the data, it removed the `\\` which meant the escaping inside the JSON was then wrong. 

Unfortunately, the use-case supporting the reason for this cleaning wasn't codified in a test and thus I'm not 100% sure what its purpose was.

* Also fix the go mod version as was erroring when building locally
* Added a cancellation context to main.go and so SIGTERM now terminates the server